### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -2,6 +2,8 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on merge
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Lementknight/blog/security/code-scanning/1](https://github.com/Lementknight/blog/security/code-scanning/1)

To fix this problem, we need to add a `permissions` block to the workflow YAML file. Since this workflow deploys to Firebase Hosting and uses actions that require some permissions, we should set the minimum required permissions. Actions such as `actions/checkout` and deployment actions typically require at least `contents: read`, and sometimes may require `contents: write` (for status updates or deployment reporting), but in most cases for deployment workflows, `contents: read` is the minimal safe value unless you're sure more is needed. Adding the following block at the same indentation as `name` (i.e., at the root of the YAML) will restrict the GITHUB_TOKEN access throughout all jobs in the workflow. If future actions require more permissions (e.g., `pull-requests: write`), they should be added. Place the new `permissions` block immediately below `name:` (between lines 4 and 5).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.

- Chores
  - Hardened CI/CD security by restricting workflow permissions to read-only for repository contents during deployments.
  - Enhances protection of the release pipeline without altering app behavior or performance.
  - No impact on features, UI, or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->